### PR TITLE
PLATFORM-7278 | Fix Jaeger trace propagation

### DIFF
--- a/configx/provider.go
+++ b/configx/provider.go
@@ -485,7 +485,8 @@ func (p *Provider) TracingConfig(serviceName string) *otelx.Config {
 		Providers: otelx.ProvidersConfig{
 			Jaeger: otelx.JaegerConfig{
 				Sampling: otelx.JaegerSampling{
-					ServerURL: p.String("tracing.providers.jaeger.sampling.server_url"),
+					ServerURL:    p.String("tracing.providers.jaeger.sampling.server_url"),
+					TraceIdRatio: p.Float64F("tracing.providers.jaeger.sampling.trace_id_ratio", 1),
 				},
 				LocalAgentAddress: p.String("tracing.providers.jaeger.local_agent_address"),
 			},

--- a/otelx/config.go
+++ b/otelx/config.go
@@ -23,7 +23,8 @@ type OTLPConfig struct {
 }
 
 type JaegerSampling struct {
-	ServerURL string `json:"server_url"`
+	ServerURL    string  `json:"server_url"`
+	TraceIdRatio float64 `json:"trace_id_ratio"`
 }
 
 type ZipkinSampling struct {

--- a/otelx/config.schema.json
+++ b/otelx/config.schema.json
@@ -59,9 +59,7 @@
             "sampling": {
               "type": "object",
               "propertyNames": {
-                "enum": [
-                  "server_url"
-                ]
+                "enum": ["server_url", "trace_id_ratio"]
               },
               "additionalProperties": false,
               "properties": {
@@ -69,9 +67,12 @@
                   "type": "string",
                   "description": "The address of jaeger-agent's HTTP sampling server",
                   "format": "uri",
-                  "examples": [
-                    "http://localhost:5778/sampling"
-                  ]
+                  "examples": ["http://localhost:5778/sampling"]
+                },
+                "trace_id_ratio": {
+                  "type": "number",
+                  "description": "Trace Id ratio sample",
+                  "examples": [0.5]
                 }
               }
             }

--- a/otelx/config_test.go
+++ b/otelx/config_test.go
@@ -34,7 +34,8 @@ func TestConfigSchema(t *testing.T) {
 				Jaeger: JaegerConfig{
 					LocalAgentAddress: "localhost:6831",
 					Sampling: JaegerSampling{
-						ServerURL: "http://localhost:5778/sampling",
+						ServerURL:    "http://localhost:5778/sampling",
+						TraceIdRatio: 1,
 					},
 				},
 			},

--- a/otelx/jaeger.go
+++ b/otelx/jaeger.go
@@ -19,6 +19,7 @@ import (
 // NOTE: If Config.Providers.Jaeger.Sampling.ServerURL is not specfied,
 // AlwaysSample is used.
 func SetupJaeger(t *Tracer, tracerName string) (trace.Tracer, error) {
+	c := t.Config
 	host, port, err := net.SplitHostPort(t.Config.Providers.Jaeger.LocalAgentAddress)
 	if err != nil {
 		return nil, err
@@ -47,6 +48,7 @@ func SetupJaeger(t *Tracer, tracerName string) (trace.Tracer, error) {
 		jaegerRemoteSampler := jaegerremote.New(
 			"jaegerremote",
 			jaegerremote.WithSamplingServerURL(samplingServerURL),
+			jaegerremote.WithInitialSampler(sdktrace.TraceIDRatioBased(c.Providers.Jaeger.Sampling.TraceIdRatio)),
 		)
 		tpOpts = append(tpOpts, sdktrace.WithSampler(jaegerRemoteSampler))
 	} else {

--- a/otelx/jaeger.go
+++ b/otelx/jaeger.go
@@ -15,12 +15,18 @@ import (
 	"go.opentelemetry.io/otel/trace"
 )
 
-// Optionally, Config.Providers.Jaeger.LocalAgentAddress can be set.
-// NOTE: If Config.Providers.Jaeger.Sampling.ServerURL is not specfied,
-// AlwaysSample is used.
+// SetupJaeger configures and returns a Jaeger tracer.
+//
+// The returned tracer will by default attempt to send spans to a local Jaeger agent.
+// Optionally, [otelx.JaegerConfig.LocalAgentAddress] can be set to specify a different target.
+//
+// By default, unless a parent sampler has taken a sampling decision, every span is sampled.
+// [otelx.JaegerSampling.TraceIdRatio] may be used to customize the sampling probability,
+// optionally alongside [otelx.JaegerSampling.ServerURL] to consult a remote server
+// for the sampling strategy to be used.
 func SetupJaeger(t *Tracer, tracerName string) (trace.Tracer, error) {
 	c := t.Config
-	host, port, err := net.SplitHostPort(t.Config.Providers.Jaeger.LocalAgentAddress)
+	host, port, err := net.SplitHostPort(c.Providers.Jaeger.LocalAgentAddress)
 	if err != nil {
 		return nil, err
 	}
@@ -42,31 +48,36 @@ func SetupJaeger(t *Tracer, tracerName string) (trace.Tracer, error) {
 		)),
 	}
 
-	samplingServerURL := t.Config.Providers.Jaeger.Sampling.ServerURL
+	samplingServerURL := c.Providers.Jaeger.Sampling.ServerURL
+	traceIdRatio := c.Providers.Jaeger.Sampling.TraceIdRatio
+
+	sampler := sdktrace.TraceIDRatioBased(traceIdRatio)
 
 	if samplingServerURL != "" {
-		jaegerRemoteSampler := jaegerremote.New(
+		sampler = jaegerremote.New(
 			"jaegerremote",
 			jaegerremote.WithSamplingServerURL(samplingServerURL),
-			jaegerremote.WithInitialSampler(sdktrace.TraceIDRatioBased(c.Providers.Jaeger.Sampling.TraceIdRatio)),
+			jaegerremote.WithInitialSampler(sampler),
 		)
-		tpOpts = append(tpOpts, sdktrace.WithSampler(jaegerRemoteSampler))
-	} else {
-		tpOpts = append(tpOpts, sdktrace.WithSampler(sdktrace.AlwaysSample()))
 	}
+
+	// Respect any sampling decision taken by the client.
+	sampler = sdktrace.ParentBased(sampler)
+	tpOpts = append(tpOpts, sdktrace.WithSampler(sampler))
+
 	tp := sdktrace.NewTracerProvider(tpOpts...)
 	otel.SetTracerProvider(tp)
 
 	// At the moment, software across our cloud stack only support Zipkin (B3)
-	// and Jaeger propagation formats. Proposals for standardized formats for
-	// context propagation are in the works (ref: https://www.w3.org/TR/trace-context/
+	// and Jaeger propagation formats. For interoperability with other setups,
+	// we also configure propagation using standardized formats for
+	// context propagation (ref: https://www.w3.org/TR/trace-context/
 	// and https://www.w3.org/TR/baggage/).
-	//
-	// Simply add propagation.TraceContext{} and propagation.Baggage{}
-	// here to enable those as well.
 	prop := propagation.NewCompositeTextMapPropagator(
 		jaegerPropagator.Jaeger{},
 		b3.New(b3.WithInjectEncoding(b3.B3MultipleHeader|b3.B3SingleHeader)),
+		propagation.TraceContext{},
+		propagation.Baggage{},
 	)
 	otel.SetTextMapPropagator(prop)
 	return tp.Tracer(tracerName), nil


### PR DESCRIPTION
The Jaeger tracer setup in `otelx` has several issues:
* It does not support probabilistic sampling at all, only remote server based sampling.
* It does not respect sampling decisions taken by remote samplers.

As a result, our Jaeger deployment is overloaded because Kratos samples every span.

So, backport 467e11ed22f3f7a9cf47b842d9076ba236680815, which makes sampling probability configurable, and augment it further to support local probabilistic sampling and respect remote sampler decisions. Add a test case for this.

Once deployed, we can upstream this fix.